### PR TITLE
fix: extra dot following an atom

### DIFF
--- a/slides/week1.tex
+++ b/slides/week1.tex
@@ -397,7 +397,7 @@ A \textbf{rule} is said to be \textbf{ground} if it all of its atoms are ground.
 
 For example:
 \begin{lstlisting}[language=flix,xleftmargin=0.8cm]
-A(1, 2, 3).                // Ground Atom
+A(1, 2, 3)                 // Ground Atom
 A(1, 2, 3) :- B(2), C(3).  // Ground Rule
 \end{lstlisting}
 \end{frame}


### PR DESCRIPTION
In page 20 of `week1.tex`.

The slides claims that `A(1, 2, 3).` is a ground atom, but it is actually a fact constraint not an atom syntactically speaking.
